### PR TITLE
Improve prompt accuracy to address common community note issues

### DIFF
--- a/src/pipeline/check.ts
+++ b/src/pipeline/check.ts
@@ -10,7 +10,7 @@ const prompt = (
   sourceUrl: string,
   sourceContent: string
 ) => `
-Given this source content and a community note, determine if the source contains information that justifies the claim made in the community note.
+Given this source content and a community note, determine if the source DIRECTLY supports the specific factual correction made in the note.
 Community note to check:
 \`\`\`
 ${missingContext}
@@ -20,9 +20,16 @@ Source content:
 \`\`\`
 ${sourceContent.substring(0, 30000)} // Limit to avoid token issues
 \`\`\`
-Analyze the source carefully and respond with ONLY:
-- “YES” if the source justifies the claim, such that a person could read it and agree with the correction
-- “NO” if the source is not very clear on the claim given, in any way.
+CRITICAL REQUIREMENTS:
+- The source must specifically address the exact claim being corrected (not just general background)
+- The source must be recent/relevant to the timeframe discussed in the original post
+- The correction must be directly supported by clear statements in the source
+- General context or tangentially related information does NOT count
+
+Respond with ONLY:
+- "YES" if the source directly and specifically supports the factual correction
+- "NO" if the source lacks direct support, is about a different timeframe, or provides only general context
+
 Do not provide any other text, quotes, or explanations. Just respond with YES or NO.`;
 
 // Helper to fetch and simplify page content

--- a/src/pipeline/searchContextGoal.ts
+++ b/src/pipeline/searchContextGoal.ts
@@ -70,7 +70,14 @@ export async function versionOneFn(
     image_url: { url },
   }));
 
-  let systemPrompt = `You are an context and factchecking tool. Search the web for information relating to the following query and always include specific URLs for your sources directly in the text.`;
+  let systemPrompt = `You are a context and factchecking tool. Search the web for information that DIRECTLY addresses or contradicts the specific claims made in the following post. 
+
+IMPORTANT: Only provide sources that:
+1. Directly support or contradict the exact claims made in the post
+2. Are recent enough to be relevant to the timeframe referenced
+3. Address the specific people, events, or facts mentioned (not general background)
+
+Always include specific URLs for your sources directly in the text.`;
   
   if (input.retweetContext) {
     systemPrompt += ` ${input.retweetContext}`;

--- a/src/pipeline/writeNoteWithSearchGoal.ts
+++ b/src/pipeline/writeNoteWithSearchGoal.ts
@@ -27,18 +27,30 @@ const promptTemplate = ({
   searchResults: string;
   citations: string[];
   retweetContext?: string;
-}) => `Given this X post and search results about it, identify the most important pieces of context that are missing from the post that would help readers understand the full picture.${retweetContext ? `
+}) => `TASK: Analyze this X post and determine if it contains factual errors that require correction.${retweetContext ? `
 
 ${retweetContext}` : ''}
 
-Focus only on factual context that materially and significantly changes the interpretation of the post. Do not flag opinions, predictions, or minor details. Please be concise and get straight to the point.
+CRITICAL ANALYSIS STEPS:
+1. IDENTIFY THE SPECIFIC CLAIM: What exact factual assertion is the post making?
+2. VERIFY ACCURACY: Do the search results directly contradict this specific claim?
+3. SOURCE RELEVANCE: Do the sources directly address this claim (not general background)?
+4. DIRECTNESS: Can you definitively say "this specific claim is false" based on the evidence?
+
+ONLY correct posts with clear factual errors supported by direct, relevant sources. Avoid:
+- General background context that doesn't contradict the claim
+- Sources about different timeframes than what the post discusses  
+- Correcting things the post never actually claimed
+- Vague corrections that don't directly address the core assertion
 
 Please start by responding with one of the following statuses "TWEET NOT SIGNIFICANTLY INCORRECT" "NO MISSING CONTEXT" "CORRECTION WITH TRUSTWORTHY CITATION" "CORRECTION WITHOUT TRUSTWORTHY CITATION"
 
-If important context is missing, write a community note to correct the claim. Always include a URL, if no url is possible respond with the relevant status. Keep the correction text to 275 characters or less (URL will be added separately). Respond with the following format:
+If writing a correction, be explicit and direct. Start with "This claim is incorrect" or "This statement is false" and explain exactly what is wrong. Keep correction text to 275 characters or less (URL will be added separately).
+
+Format:
 [Status]
-[Short correction of most significant error]
-[URL of most trustworthy source]
+[Direct correction stating exactly what is wrong]
+[URL that specifically contradicts the claim]
 
 Post perhaps in need of community note:
 \`\`\`
@@ -68,18 +80,30 @@ const retryPromptTemplate = ({
   retweetContext?: string;
   previousNote: string;
   characterCount: number;
-}) => `Given this X post and search results about it, identify the most important pieces of context that are missing from the post that would help readers understand the full picture.${retweetContext ? `
+}) => `TASK: Analyze this X post and determine if it contains factual errors that require correction.${retweetContext ? `
 
 ${retweetContext}` : ''}
 
-Focus only on factual context that materially and significantly changes the interpretation of the post. Do not flag opinions, predictions, or minor details. Please be concise and get straight to the point.
+CRITICAL ANALYSIS STEPS:
+1. IDENTIFY THE SPECIFIC CLAIM: What exact factual assertion is the post making?
+2. VERIFY ACCURACY: Do the search results directly contradict this specific claim?
+3. SOURCE RELEVANCE: Do the sources directly address this claim (not general background)?
+4. DIRECTNESS: Can you definitively say "this specific claim is false" based on the evidence?
+
+ONLY correct posts with clear factual errors supported by direct, relevant sources. Avoid:
+- General background context that doesn't contradict the claim
+- Sources about different timeframes than what the post discusses  
+- Correcting things the post never actually claimed
+- Vague corrections that don't directly address the core assertion
 
 Please start by responding with one of the following statuses "TWEET NOT SIGNIFICANTLY INCORRECT" "NO MISSING CONTEXT" "CORRECTION WITH TRUSTWORTHY CITATION" "CORRECTION WITHOUT TRUSTWORTHY CITATION"
 
-If important context is missing, write a community note to correct the claim. Always include a URL, if no url is possible respond with the relevant status. Keep the correction text to 275 characters or less (URL will be added separately). Respond with the following format:
+If writing a correction, be explicit and direct. Start with "This claim is incorrect" or "This statement is false" and explain exactly what is wrong. Keep correction text to 275 characters or less (URL will be added separately).
+
+Format:
 [Status]
-[Short correction of most significant error]
-[URL of most trustworthy source]
+[Direct correction stating exactly what is wrong]
+[URL that specifically contradicts the claim]
 
 🚨 CRITICAL FAILURE: Your previous note was ${characterCount} characters - this VIOLATES the strict 275 character limit! You MUST drastically reduce this length NOW. This is NOT a suggestion - it is MANDATORY.
 


### PR DESCRIPTION
Enhanced prompts across the pipeline to fix three critical issues:

1. Source irrelevance: Updated search and check prompts to require direct, specific contradictions rather than general context
2. Claim misinterpretation: Added step-by-step analysis to identify exact claims before attempting corrections
3. Vague corrections: Required explicit "This claim is incorrect" language and direct addressing of core assertions

Changes focus on ensuring sources directly contradict specific claims rather than providing tangential background information.

🤖 Generated with [Claude Code](https://claude.ai/code)